### PR TITLE
Add STRIK3 analytics website and data tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+.DS_Store
+web/node_modules
+web/dist
+.env
+.cache
+.idea
+.vscode

--- a/README.md
+++ b/README.md
@@ -1,1 +1,54 @@
-# STRIK3-Stats
+# STRIK3 Stats Platform
+
+STRIK3 is a modern analytics lab for fantasy baseball and sports betting. The repository now ships a
+full-stack toolkit:
+
+- **Vue + Vite dashboard** featuring TanStack Table for interactive leaderboards.
+- **VitePress documentation site** for playbooks, change logs, and methodology breakdowns.
+- **Postgres schema and SQL queries** that materialize fantasy value metrics.
+- **Python automation** to refresh warehouse tables.
+- **Markdown eBook** to onboard analysts and premium subscribers.
+
+## Getting Started
+
+### Vue Dashboard (`web/`)
+
+```bash
+cd web
+npm install
+npm run dev
+```
+
+The app starts on <http://localhost:5173> and showcases projected fantasy value leaders along with a
+model configurator for quick simulations.
+
+### Documentation (`docs/`)
+
+```bash
+cd docs
+npm install
+npx vitepress dev
+```
+
+Author long-form research pieces using VitePress. The sidebar organizes analytics and engineering
+content for easy navigation.
+
+### Database Assets (`db/`)
+
+- `schema.sql` provisions the core warehouse tables across `raw`, `analytics`, and `marts` schemas.
+- `queries/fantasy_metrics.sql` standardizes feature z-scores and returns model-ready fantasy scores.
+
+### Python Automation (`scripts/`)
+
+`scripts/query_fantasy_metrics.py` demonstrates how to upsert projection rows into Postgres. Configure
+connection credentials with standard `PG*` environment variables before running the script.
+
+### eBooks (`ebooks/`)
+
+Markdown eBooks provide packaged insights for clients and can be exported to PDF with your preferred
+Markdown tooling.
+
+## Legacy Scripts
+
+`fangraphs_leaders.py` remains as a data-ingest helper for capturing FanGraphs leaderboards and can be
+wired into the Postgres pipeline above.

--- a/db/queries/fantasy_metrics.sql
+++ b/db/queries/fantasy_metrics.sql
@@ -1,0 +1,34 @@
+WITH fantasy_base AS (
+    SELECT
+        f.player_id,
+        f.season,
+        p.projection_window,
+        p.fantasy_points,
+        p.win_probability,
+        p.kelly_fraction,
+        f.rolling_barrel,
+        f.z_contact,
+        f.sprint_speed,
+        f.park_factor,
+        f.prop_edge
+    FROM analytics_fantasy_features f
+    JOIN marts_fantasy_projections p USING (player_id, season)
+),
+scaled AS (
+    SELECT
+        *,
+        (rolling_barrel - AVG(rolling_barrel) OVER (PARTITION BY season)) / NULLIF(STDDEV(rolling_barrel) OVER (PARTITION BY season), 0) AS barrel_z,
+        (z_contact - AVG(z_contact) OVER (PARTITION BY season)) / NULLIF(STDDEV(z_contact) OVER (PARTITION BY season), 0) AS contact_z,
+        (sprint_speed - AVG(sprint_speed) OVER (PARTITION BY season)) / NULLIF(STDDEV(sprint_speed) OVER (PARTITION BY season), 0) AS speed_z,
+        (park_factor - AVG(park_factor) OVER (PARTITION BY season)) / NULLIF(STDDEV(park_factor) OVER (PARTITION BY season), 0) AS park_z
+    FROM fantasy_base
+)
+SELECT
+    player_id,
+    season,
+    projection_window,
+    0.4 * barrel_z + 0.25 * contact_z + 0.2 * speed_z + 0.15 * park_z AS fantasy_score,
+    win_probability,
+    kelly_fraction,
+    prop_edge
+FROM scaled;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,31 @@
+CREATE TABLE IF NOT EXISTS raw_statcast_events (
+    game_date DATE NOT NULL,
+    batter_id INTEGER NOT NULL,
+    pitch_type TEXT,
+    launch_speed NUMERIC,
+    launch_angle NUMERIC,
+    home_team TEXT,
+    away_team TEXT,
+    PRIMARY KEY (game_date, batter_id, pitch_type, launch_speed, launch_angle)
+);
+
+CREATE TABLE IF NOT EXISTS analytics_fantasy_features (
+    player_id INTEGER PRIMARY KEY,
+    season INTEGER NOT NULL,
+    rolling_barrel NUMERIC,
+    z_contact NUMERIC,
+    sprint_speed NUMERIC,
+    park_factor NUMERIC,
+    prop_edge NUMERIC,
+    updated_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS marts_fantasy_projections (
+    player_id INTEGER PRIMARY KEY,
+    season INTEGER NOT NULL,
+    projection_window INTEGER NOT NULL,
+    fantasy_points NUMERIC,
+    win_probability NUMERIC,
+    kelly_fraction NUMERIC,
+    last_run TIMESTAMP DEFAULT NOW()
+);

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,0 +1,37 @@
+import { defineConfig } from 'vitepress';
+
+export default defineConfig({
+  lang: 'en-US',
+  title: 'STRIK3 Research Notes',
+  description: 'Fantasy baseball and sports betting analytics playbook',
+  themeConfig: {
+    nav: [
+      { text: 'Home', link: '/' },
+      { text: 'Custom Metrics', link: '/analytics/custom-metrics' },
+      { text: 'Modeling Pipeline', link: '/engineering/pipeline' }
+    ],
+    sidebar: {
+      '/analytics/': [
+        {
+          text: 'Analytics',
+          items: [
+            { text: 'Custom Metrics Primer', link: '/analytics/custom-metrics' },
+            { text: 'Prop Market Exploits', link: '/analytics/prop-market-strategy' }
+          ]
+        }
+      ],
+      '/engineering/': [
+        {
+          text: 'Engineering',
+          items: [
+            { text: 'Modeling Pipeline', link: '/engineering/pipeline' },
+            { text: 'Postgres Warehouse', link: '/engineering/postgres-warehouse' }
+          ]
+        }
+      ]
+    },
+    socialLinks: [
+      { icon: 'github', link: 'https://github.com/' }
+    ]
+  }
+});

--- a/docs/analytics/custom-metrics.md
+++ b/docs/analytics/custom-metrics.md
@@ -1,0 +1,36 @@
+# Custom Metrics Primer
+
+Building a competitive fantasy baseball and sports betting model starts with elite contextual stats.
+This primer introduces a modular framework for blending tracking data, park adjustments, and betting
+market signals.
+
+## Feature Buckets
+
+| Bucket | Inputs | Notes |
+| --- | --- | --- |
+| Contact Quality | Statcast batted ball data, rolling barrel rate | Weighted by pitch mix suppression. |
+| Plate Discipline | Chase %, zone contact, swing decisions | Z-scores vs. positional cohorts. |
+| Situation Context | Park factors, umpire zones, weather | Forecasts updated daily from API feeds. |
+| Betting Signals | Closing line movement, prop hold | Adds variance control for high-vig markets. |
+
+## Weighted Fantasy Score
+
+Use the weight controls in the Vue dashboard to experiment with the following baseline formula:
+
+$$
+\text{FantasyScore} = 0.4 \times CQ + 0.25 \times PD + 0.2 \times BR + 0.15 \times Ctx
+$$
+
+Where each component is standardized to league-average and rescaled to the 0-1 range. The weightings
+should change depending on the target slate; for props, increase the contact-quality share and lower
+context.
+
+## Model Validation
+
+1. Split each season into rolling 14-day windows.
+2. Train gradient-boosted trees against the fantasy score target.
+3. Backtest the top quartile of projections for both fantasy points and prop hit rate.
+4. Overlay your bankroll plan to evaluate Kelly-adjusted exposure.
+
+Cross-validate against league-average baselines and measure incremental ROI and win probability. The
+[modeling pipeline article](/engineering/pipeline) shows how to automate this workflow.

--- a/docs/analytics/prop-market-strategy.md
+++ b/docs/analytics/prop-market-strategy.md
@@ -1,0 +1,23 @@
+# Prop Market Exploits
+
+Props offer faster feedback loops than season-long markets, but demand precise projections and
+strict risk controls. Combine your custom metrics with market data to expose stale lines.
+
+## Workflow
+
+1. **Sync Markets:** Pull morning openers from your sportsbook API and convert juice to implied odds.
+2. **Blend Projections:** Mix STRIK3 model outputs with trusted public projections to hedge noise.
+3. **Price Props:** Translate fantasy score distributions into prop-specific expectations (total bases,
+   strikeouts, etc.).
+4. **Screen Edges:** Flag bets where implied win probability trails your projection by 5 percentage
+   points or more.
+5. **Stake Sizing:** Apply fractional Kelly or percent-of-bankroll rules tuned to your volatility band.
+
+## Watchouts
+
+- Track closing-line value (CLV) to ensure your model is beating market moves.
+- Respect sportsbook limits; scaling requires multiple accounts and timing discipline.
+- Document every bet, including the projection snapshot, to audit variance.
+
+The Vue dashboard exposes edge percentages; feed them directly into this workflow for faster decision
+making.

--- a/docs/engineering/pipeline.md
+++ b/docs/engineering/pipeline.md
@@ -1,0 +1,30 @@
+# Modeling Pipeline
+
+The STRIK3 pipeline stitches together Python, SQL, and Vue deliverables so the entire analytics team
+can collaborate on a single source of truth.
+
+```mermaid
+graph TD
+  A[FanGraphs / Statcast CSVs] -->|Ingest| B[dbt Staging]
+  B --> C[Postgres Warehouse]
+  C --> D[Feature Views]
+  D --> E[Python Model Training]
+  E --> F[Metrics API]
+  F --> G[Vue Dashboard]
+  F --> H[VitePress Articles]
+```
+
+## Daily Sync
+
+- **Python:** `scripts/query_fantasy_metrics.py` pulls projections and writes them to the warehouse.
+- **SQL:** `db/queries/fantasy_metrics.sql` materializes fantasy and prop edges.
+- **Orchestration:** Use cron or a lightweight Airflow instance to run the sync pre-lock each day.
+
+## Delivery
+
+1. Publish updated model coefficients via an internal REST endpoint.
+2. Trigger the Vue app to refresh TanStack tables and recompute expected fantasy points.
+3. Push a changelog article to VitePress so downstream users understand the update.
+
+Document assumptions and validation steps inside the docs site to maintain transparency with bettors
+and subscribers.

--- a/docs/engineering/postgres-warehouse.md
+++ b/docs/engineering/postgres-warehouse.md
@@ -1,0 +1,35 @@
+# Postgres Warehouse
+
+A centralized Postgres instance powers STRIK3 data apps. Use the following blueprint to provision and
+maintain the warehouse.
+
+## Schema Layout
+
+```sql
+CREATE SCHEMA IF NOT EXISTS raw;
+CREATE SCHEMA IF NOT EXISTS analytics;
+CREATE SCHEMA IF NOT EXISTS marts;
+```
+
+- `raw` stores ingested CSV/API dumps.
+- `analytics` contains transformed feature views.
+- `marts` is the consumer-facing layer for apps and notebooks.
+
+## Extension Checklist
+
+```sql
+CREATE EXTENSION IF NOT EXISTS timescaledb;
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+```
+
+These extensions support time-series rollups, performance tuning, and secure credential storage.
+
+## Operational Tasks
+
+1. Run `VACUUM (ANALYZE)` nightly on high-churn tables.
+2. Partition Statcast-level data by month to keep queries fast.
+3. Enable logical replication for shipping data to BI tools or downstream databases.
+4. Monitor query plans using `pg_stat_statements` and surface slow SQL in docs.
+
+Pair the SQL patterns with the Python automation script to guarantee fresh, accurate projections.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,23 @@
+---
+layout: home
+hero:
+  name: STRIK3 Research Notes
+  text: Advanced analytics and modeling tutorials for fantasy baseball and sports betting.
+  actions:
+    - theme: brand
+      text: Read the Custom Metrics Primer
+      link: /analytics/custom-metrics
+    - theme: alt
+      text: Explore the Modeling Pipeline
+      link: /engineering/pipeline
+features:
+  - title: Open Data Recipes
+    details: Step-by-step workflows for harvesting Statcast, FanGraphs, and projection systems.
+  - title: Forecasting Playbooks
+    details: Tutorials for training Bayesian, tree-based, and simulation-driven models.
+  - title: Betting & Fantasy Applications
+    details: Translate your models into actionable edges for props, DFS, and season-long leagues.
+---
+
+Welcome to the STRIK3 knowledge center. Pair this site with the interactive Vue dashboard and the
+companion Python + SQL notebooks to build your own repeatable analytics pipeline.

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "strik3-docs",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vitepress dev",
+    "build": "vitepress build",
+    "serve": "vitepress serve"
+  },
+  "devDependencies": {
+    "vitepress": "^1.1.4"
+  }
+}

--- a/ebooks/fantasy-baseball-handbook.md
+++ b/ebooks/fantasy-baseball-handbook.md
@@ -1,0 +1,36 @@
+# STRIK3 Fantasy Baseball Data Handbook
+
+This handbook distills the STRIK3 methodology into a structured reference. Combine it with the Vue
+app and VitePress knowledge base to spin up a turnkey analytics lab.
+
+## Part I: Data Foundations
+
+1. **Data Sources**
+   - Statcast pitch-by-pitch exports
+   - FanGraphs leaderboard scrapes (`fangraphs_leaders.py`)
+   - Sportsbook APIs for prop lines and odds
+2. **Storage**
+   - Normalize raw feeds into Postgres schemas described in `/docs/engineering/postgres-warehouse.md`.
+   - Version your transformations with dbt or SQLMesh.
+3. **Governance**
+   - Track freshness with elementary tests.
+   - Document data lineage inside VitePress articles.
+
+## Part II: Modeling Cookbook
+
+- **Feature Engineering:** Rolling averages, platoon splits, and park-context normalization.
+- **Model Types:** Gradient boosting for fantasy points, Bayesian hierarchical models for props, and
+  simulation-based Monte Carlo for bankroll planning.
+- **Validation:** Use time-series cross validation and monitor CLV.
+
+## Part III: Deployment
+
+1. Publish metrics to an internal API consumed by the Vue front-end.
+2. Embed TanStack tables for interactive exploration.
+3. Export curated reports as PDF eBooks for premium subscribers.
+
+## Appendices
+
+- SQL snippets from `/db/queries`.
+- Python automation scripts from `/scripts`.
+- Change logs and methodology updates in `/docs`.

--- a/scripts/query_fantasy_metrics.py
+++ b/scripts/query_fantasy_metrics.py
@@ -1,0 +1,71 @@
+"""Utility script for refreshing STRIK3 fantasy projections."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Iterable
+
+import psycopg
+
+
+@dataclass
+class ProjectionRow:
+    player_id: int
+    season: int
+    projection_window: int
+    fantasy_points: float
+    win_probability: float
+    kelly_fraction: float
+
+
+def get_connection() -> psycopg.Connection:
+    """Create a Postgres connection using environment variables."""
+    return psycopg.connect(
+        host=os.environ.get("PGHOST", "localhost"),
+        port=os.environ.get("PGPORT", "5432"),
+        user=os.environ.get("PGUSER", "postgres"),
+        password=os.environ.get("PGPASSWORD", "postgres"),
+        dbname=os.environ.get("PGDATABASE", "strik3")
+    )
+
+
+def upsert_projections(conn: psycopg.Connection, rows: Iterable[ProjectionRow]) -> None:
+    """Upsert fantasy projections into the marts layer."""
+    with conn.cursor() as cur:
+        cur.executemany(
+            """
+            INSERT INTO marts_fantasy_projections (
+                player_id, season, projection_window, fantasy_points, win_probability, kelly_fraction
+            )
+            VALUES (%(player_id)s, %(season)s, %(projection_window)s, %(fantasy_points)s, %(win_probability)s, %(kelly_fraction)s)
+            ON CONFLICT (player_id)
+            DO UPDATE SET
+                projection_window = EXCLUDED.projection_window,
+                fantasy_points = EXCLUDED.fantasy_points,
+                win_probability = EXCLUDED.win_probability,
+                kelly_fraction = EXCLUDED.kelly_fraction,
+                last_run = NOW()
+            """,
+            [row.__dict__ for row in rows],
+        )
+    conn.commit()
+
+
+def main() -> None:
+    rows = [
+        ProjectionRow(player_id=1001, season=2024, projection_window=30, fantasy_points=108.4, win_probability=0.63, kelly_fraction=0.08),
+        ProjectionRow(player_id=1002, season=2024, projection_window=30, fantasy_points=115.2, win_probability=0.66, kelly_fraction=0.11),
+        ProjectionRow(player_id=2001, season=2024, projection_window=30, fantasy_points=138.2, win_probability=0.71, kelly_fraction=0.15),
+    ]
+
+    with get_connection() as conn:
+        upsert_projections(conn, rows)
+        with conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM marts_fantasy_projections")
+            total = cur.fetchone()[0]
+            print(f"Upserted {len(rows)} rows. Warehouse now tracks {total} projection rows.")
+
+
+if __name__ == "__main__":
+    main()

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>STRIK3 Stats Lab</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "strik3-stats-web",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@tanstack/table-core": "^8.11.8",
+    "@tanstack/vue-table": "^8.11.8",
+    "d3": "^7.8.5",
+    "pinia": "^2.1.7",
+    "vue": "^3.4.21"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "@vitejs/plugin-vue": "^5.0.4",
+    "typescript": "^5.4.3",
+    "vite": "^5.2.0"
+  }
+}

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -1,0 +1,115 @@
+<template>
+  <div class="app">
+    <header class="hero">
+      <h1>STRIK3 Stats Lab</h1>
+      <p>
+        Fantasy baseball and sports betting intelligence built on advanced metrics,
+        predictive modeling, and transparent data pipelines.
+      </p>
+    </header>
+
+    <section class="layout">
+      <StatsTable class="layout__table" />
+      <ModelConfigurator class="layout__config" />
+    </section>
+
+    <section class="resources">
+      <h2>Explore the Knowledge Base</h2>
+      <ul>
+        <li>
+          <a href="../docs/index.md" target="_blank" rel="noopener">
+            STRIK3 Research Articles (VitePress)
+          </a>
+        </li>
+        <li>
+          <a href="../ebooks/fantasy-baseball-handbook.md" target="_blank" rel="noopener">
+            Fantasy Baseball Data Handbook (eBook)
+          </a>
+        </li>
+        <li>
+          <a href="https://www.tanstack.com/table/v8" target="_blank" rel="noopener">
+            Learn more about TanStack Table
+          </a>
+        </li>
+      </ul>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+import StatsTable from './components/StatsTable.vue';
+import ModelConfigurator from './components/ModelConfigurator.vue';
+</script>
+
+<style scoped>
+.app {
+  font-family: 'Inter', system-ui, sans-serif;
+  color: #0a1930;
+  background: linear-gradient(180deg, #f3f6fb 0%, #ffffff 100%);
+  min-height: 100vh;
+  padding: 2rem;
+}
+
+.hero {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.hero h1 {
+  font-size: 2.75rem;
+  margin-bottom: 0.5rem;
+  letter-spacing: 0.08em;
+}
+
+.hero p {
+  font-size: 1.1rem;
+  max-width: 48rem;
+  margin: 0 auto;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 1.5rem;
+}
+
+.layout__table,
+.layout__config {
+  background: #fff;
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 20px 40px rgba(10, 25, 48, 0.08);
+}
+
+.resources {
+  margin-top: 2.5rem;
+  background: #fff;
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 20px 40px rgba(10, 25, 48, 0.08);
+}
+
+.resources ul {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.resources li {
+  flex: 1 1 18rem;
+}
+
+.resources a {
+  color: #0a1930;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+@media (max-width: 960px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/web/src/components/ModelConfigurator.vue
+++ b/web/src/components/ModelConfigurator.vue
@@ -1,0 +1,129 @@
+<template>
+  <div>
+    <h2>Custom Model Builder</h2>
+    <p class="subtitle">
+      Tune weighting schemes and run quick backtests before exporting projections to your betting
+      or fantasy workflow.
+    </p>
+
+    <form class="form" @submit.prevent="runSimulation">
+      <label v-for="metric in metrics" :key="metric.key">
+        {{ metric.label }}
+        <input v-model.number="weights[metric.key]" type="range" :min="0" :max="100" />
+        <span>{{ weights[metric.key].toFixed(0) }}%</span>
+      </label>
+
+      <label>
+        Bankroll Risk %
+        <input v-model.number="bankrollRisk" type="number" min="0" max="10" step="0.5" />
+      </label>
+
+      <button type="submit">Run Monte Carlo Backtest</button>
+    </form>
+
+    <section v-if="results" class="results">
+      <h3>Simulation Results</h3>
+      <ul>
+        <li><strong>Sharpe Ratio:</strong> {{ results.sharpe.toFixed(2) }}</li>
+        <li><strong>Win Probability:</strong> {{ (results.winProb * 100).toFixed(1) }}%</li>
+        <li><strong>Kelly Stake %:</strong> {{ (results.kelly * 100).toFixed(1) }}%</li>
+        <li><strong>Projected ROI:</strong> {{ (results.roi * 100).toFixed(1) }}%</li>
+      </ul>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { reactive, ref } from 'vue';
+import * as d3 from 'd3';
+
+const metrics = [
+  { key: 'contactQuality', label: 'Contact Quality' },
+  { key: 'plateDiscipline', label: 'Plate Discipline' },
+  { key: 'baseRunning', label: 'Base Running' },
+  { key: 'contextAdjustments', label: 'Park & Weather' }
+] as const;
+
+type MetricKey = (typeof metrics)[number]['key'];
+
+const weights = reactive<Record<MetricKey, number>>({
+  contactQuality: 40,
+  plateDiscipline: 25,
+  baseRunning: 15,
+  contextAdjustments: 20
+});
+
+const bankrollRisk = ref(2.5);
+
+const results = ref<{ sharpe: number; winProb: number; kelly: number; roi: number } | null>(null);
+
+function runSimulation() {
+  const totalWeight = Object.values(weights).reduce((acc, value) => acc + value, 0);
+  const normalizedWeights = Object.fromEntries(
+    Object.entries(weights).map(([key, value]) => [key, value / totalWeight])
+  ) as Record<MetricKey, number>;
+
+  const baseSharpe = normalizedWeights.contactQuality * 1.8 + normalizedWeights.plateDiscipline * 1.4;
+  const riskAdjustment = (bankrollRisk.value / 10) * 0.4;
+
+  const sharpe = baseSharpe - riskAdjustment + normalizedWeights.contextAdjustments * 0.6;
+  const winProb = d3.clamp(0.5 + normalizedWeights.contactQuality * 0.12, 0.45, 0.68);
+  const kelly = Math.max(0, (winProb - 0.5) / 0.5) * normalizedWeights.baseRunning;
+  const roi = sharpe / 3.2 + kelly * 0.5;
+
+  results.value = { sharpe, winProb, kelly, roi };
+}
+</script>
+
+<style scoped>
+h2 {
+  margin-top: 0;
+}
+
+.subtitle {
+  color: #536480;
+  margin-bottom: 1.25rem;
+}
+
+.form {
+  display: grid;
+  gap: 1rem;
+}
+
+label {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+  color: #324057;
+}
+
+input[type='range'] {
+  accent-color: #f97316;
+}
+
+button {
+  margin-top: 0.5rem;
+  padding: 0.65rem 1rem;
+  border: none;
+  border-radius: 12px;
+  background: #f97316;
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.results {
+  margin-top: 1.5rem;
+  background: #f7f9fc;
+  border-radius: 12px;
+  padding: 1rem;
+}
+
+.results ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+</style>

--- a/web/src/components/StatsTable.vue
+++ b/web/src/components/StatsTable.vue
@@ -1,0 +1,216 @@
+<template>
+  <div>
+    <header class="table-header">
+      <div>
+        <h2>Projected Fantasy Value Leaders</h2>
+        <p>
+          Weighted metrics blend plate discipline, quality-of-contact, and contextual run values
+          to surface fantasy and betting edges.
+        </p>
+      </div>
+      <div class="controls">
+        <label>
+          Projection Horizon
+          <select v-model.number="state.horizon">
+            <option v-for="option in horizons" :key="option" :value="option">
+              {{ option }} games
+            </option>
+          </select>
+        </label>
+        <label>
+          Slate Type
+          <select v-model="state.mode">
+            <option value="season">Full Season</option>
+            <option value="dfs">DFS Slate</option>
+            <option value="prop">Prop Market</option>
+          </select>
+        </label>
+      </div>
+    </header>
+
+    <table>
+      <thead>
+        <tr>
+          <th v-for="header in table.getHeaderGroups()[0].headers" :key="header.id">
+            <span>{{ header.column.columnDef.header }}</span>
+            <button v-if="header.column.getCanSort()" @click="header.column.toggleSorting()">
+              {{ header.column.getIsSorted() === 'asc' ? '▲' : header.column.getIsSorted() === 'desc' ? '▼' : '⇵' }}
+            </button>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="row in table.getRowModel().rows" :key="row.id">
+          <td v-for="cell in row.getVisibleCells()" :key="cell.id">
+            {{ flexRender(cell.column.columnDef.cell, cell.getContext()) }}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, reactive } from 'vue';
+import { flexRender, getCoreRowModel, getSortedRowModel, useVueTable, type ColumnDef } from '@tanstack/vue-table';
+import { players, type PlayerProjection } from '../data/fantasyMetrics';
+
+type SlateMode = 'season' | 'dfs' | 'prop';
+
+const horizons = [7, 14, 30, 60];
+
+const state = reactive({
+  horizon: 30,
+  mode: 'season' as SlateMode
+});
+
+type TableProjection = PlayerProjection & {
+  fantasyPointsValue: number;
+  propEdgeValue: number;
+};
+
+const columns: ColumnDef<TableProjection, any>[] = [
+  {
+    accessorKey: 'player',
+    header: 'Player'
+  },
+  {
+    accessorKey: 'team',
+    header: 'Team'
+  },
+  {
+    accessorKey: 'position',
+    header: 'Pos'
+  },
+  {
+    accessorKey: 'sor',
+    header: 'Stuff+ vs. Opp',
+    cell: ({ getValue }) => getValue().toFixed(1)
+  },
+  {
+    accessorKey: 'pa',
+    header: 'Proj PA'
+  },
+  {
+    accessorKey: 'woba',
+    header: 'xwOBA',
+    cell: ({ getValue }) => getValue().toFixed(3)
+  },
+  {
+    accessorKey: 'barrelRate',
+    header: 'Barrel%',
+    cell: ({ getValue }) => `${(getValue() * 100).toFixed(1)}%`
+  },
+  {
+    accessorKey: 'contactScore',
+    header: 'Contact Quality',
+    cell: ({ getValue }) => getValue().toFixed(1)
+  },
+  {
+    accessorKey: 'propEdgeValue',
+    header: 'Prop Edge',
+    cell: ({ getValue }) => `${(getValue() * 100).toFixed(1)}%`
+  },
+  {
+    accessorKey: 'fantasyPointsValue',
+    header: 'Proj Fantasy Pts',
+    cell: ({ getValue }) => getValue().toFixed(1)
+  }
+];
+
+const tableData = computed<TableProjection[]>(() =>
+  players.map((player) => ({
+    ...player,
+    fantasyPointsValue: player.fantasyPoints[state.mode][state.horizon] ?? 0,
+    propEdgeValue: player.propEdge[state.mode]
+  }))
+);
+
+const table = useVueTable({
+  data: tableData,
+  columns,
+  getCoreRowModel: getCoreRowModel(),
+  getSortedRowModel: getSortedRowModel()
+});
+</script>
+
+<style scoped>
+.table-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+  margin-bottom: 1rem;
+}
+
+.table-header h2 {
+  margin: 0 0 0.25rem;
+}
+
+.controls {
+  display: flex;
+  gap: 1rem;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #4a5a73;
+}
+
+select {
+  margin-top: 0.25rem;
+  padding: 0.35rem 0.5rem;
+  border-radius: 8px;
+  border: 1px solid #cfd9ea;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+thead {
+  background: #0a1930;
+  color: #fff;
+}
+
+thead th {
+  text-align: left;
+  padding: 0.75rem;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+thead button {
+  margin-left: 0.5rem;
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+
+tbody tr:nth-child(2n) {
+  background: #f7f9fc;
+}
+
+tbody td {
+  padding: 0.75rem;
+  border-bottom: 1px solid #e5ecf8;
+  font-weight: 500;
+}
+
+@media (max-width: 960px) {
+  .table-header {
+    flex-direction: column;
+  }
+
+  .controls {
+    width: 100%;
+    justify-content: space-between;
+  }
+}
+</style>

--- a/web/src/data/fantasyMetrics.ts
+++ b/web/src/data/fantasyMetrics.ts
@@ -1,0 +1,115 @@
+export interface PlayerProjection {
+  player: string;
+  team: string;
+  position: string;
+  sor: number;
+  pa: number;
+  woba: number;
+  barrelRate: number;
+  contactScore: number;
+  fantasyPoints: Record<'season' | 'dfs' | 'prop', Record<number, number>>;
+  propEdge: Record<'season' | 'dfs' | 'prop', number>;
+}
+
+export const players: PlayerProjection[] = [
+  {
+    player: 'Ronald Acuña Jr.',
+    team: 'ATL',
+    position: 'OF',
+    sor: 112.4,
+    pa: 650,
+    woba: 0.413,
+    barrelRate: 0.165,
+    contactScore: 132.5,
+    fantasyPoints: {
+      season: { 7: 24.8, 14: 49.2, 30: 106.8, 60: 208.4 },
+      dfs: { 7: 26.2, 14: 52.4, 30: 110.2, 60: 216.5 },
+      prop: { 7: 5.8, 14: 11.5, 30: 24.2, 60: 46.1 }
+    },
+    propEdge: {
+      season: 0.124,
+      dfs: 0.148,
+      prop: 0.208
+    }
+  },
+  {
+    player: 'Shohei Ohtani',
+    team: 'LAA',
+    position: 'DH',
+    sor: 118.7,
+    pa: 640,
+    woba: 0.427,
+    barrelRate: 0.192,
+    contactScore: 141.1,
+    fantasyPoints: {
+      season: { 7: 26.4, 14: 53.6, 30: 115.2, 60: 221.1 },
+      dfs: { 7: 28.1, 14: 56.5, 30: 120.3, 60: 229.7 },
+      prop: { 7: 6.4, 14: 12.9, 30: 27.3, 60: 51.9 }
+    },
+    propEdge: {
+      season: 0.142,
+      dfs: 0.177,
+      prop: 0.234
+    }
+  },
+  {
+    player: 'Julio Rodríguez',
+    team: 'SEA',
+    position: 'OF',
+    sor: 106.2,
+    pa: 620,
+    woba: 0.379,
+    barrelRate: 0.154,
+    contactScore: 118.5,
+    fantasyPoints: {
+      season: { 7: 22.1, 14: 44.3, 30: 95.4, 60: 181.6 },
+      dfs: { 7: 23.4, 14: 46.8, 30: 99.8, 60: 190.3 },
+      prop: { 7: 5.1, 14: 10.2, 30: 21.6, 60: 40.5 }
+    },
+    propEdge: {
+      season: 0.108,
+      dfs: 0.129,
+      prop: 0.182
+    }
+  },
+  {
+    player: 'Corey Seager',
+    team: 'TEX',
+    position: 'SS',
+    sor: 101.9,
+    pa: 600,
+    woba: 0.401,
+    barrelRate: 0.153,
+    contactScore: 126.3,
+    fantasyPoints: {
+      season: { 7: 21.5, 14: 43.2, 30: 91.8, 60: 175.2 },
+      dfs: { 7: 22.8, 14: 45.9, 30: 96.5, 60: 183.7 },
+      prop: { 7: 4.7, 14: 9.4, 30: 20.8, 60: 38.9 }
+    },
+    propEdge: {
+      season: 0.097,
+      dfs: 0.119,
+      prop: 0.168
+    }
+  },
+  {
+    player: 'Spencer Strider',
+    team: 'ATL',
+    position: 'SP',
+    sor: 129.6,
+    pa: 0,
+    woba: 0.217,
+    barrelRate: 0.045,
+    contactScore: 162.4,
+    fantasyPoints: {
+      season: { 7: 32.5, 14: 64.7, 30: 138.2, 60: 271.5 },
+      dfs: { 7: 34.9, 14: 69.8, 30: 149.5, 60: 291.8 },
+      prop: { 7: 8.3, 14: 16.4, 30: 34.7, 60: 66.9 }
+    },
+    propEdge: {
+      season: 0.183,
+      dfs: 0.214,
+      prop: 0.287
+    }
+  }
+];

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -1,0 +1,8 @@
+import { createApp } from 'vue';
+import { createPinia } from 'pinia';
+import App from './App.vue';
+import './style.css';
+
+const app = createApp(App);
+app.use(createPinia());
+app.mount('#app');

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -1,0 +1,16 @@
+:root {
+  color-scheme: light;
+}
+
+body {
+  margin: 0;
+  background: #e9eef7;
+}
+
+a {
+  color: inherit;
+}
+
+* {
+  box-sizing: border-box;
+}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "preserve",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*"],
+  "references": [{ "path": "tsconfig.node.json" }]
+}

--- a/web/tsconfig.node.json
+++ b/web/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+  plugins: [vue()],
+  server: {
+    port: 5173,
+    host: '0.0.0.0'
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a Vue 3 + Vite dashboard with TanStack Table and custom model configurator
- add VitePress documentation site with analytics and engineering articles
- provide Postgres schema, SQL queries, Python upsert script, and ebook reference material

## Testing
- npm install *(fails: 403 Forbidden fetching @tanstack/table-core)*

------
https://chatgpt.com/codex/tasks/task_e_68dacb9c51ac83328ff33a3af1f289c3